### PR TITLE
Add validation to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Valida supports both synchronous and asynchronous validation.
 * `len`
 * `array`
 * `plainObject`
+* `date`
 
 #### required
 
@@ -189,6 +190,16 @@ Field must be a plain object.
 ```js
 var schema = {
   person: [{ validator: Valida.Validator.plainObject }]
+};
+```
+
+#### array
+
+Field must be a date.
+
+```js
+var schema = {
+  createdAt: [{ validator: Valida.Validator.date }]
 };
 ```
 

--- a/examples/validator-date.js
+++ b/examples/validator-date.js
@@ -1,0 +1,50 @@
+var Valida = require('..');
+
+
+var schema = {
+  date: [
+    { validator: Valida.Validator.date }
+  ]
+};
+
+
+var data = { date: null };
+
+
+Valida.process(data, schema, function(err, ctx) {
+  if (err) return console.log(err);
+  if (!ctx.isValid()) return console.log('invalid', ctx.errors());
+  console.log('valid');
+});
+
+
+data.date = 'some-string';
+Valida.process(data, schema, function(err, ctx) {
+  if (err) return console.log(err);
+  if (!ctx.isValid()) return console.log('invalid', ctx.errors());
+  console.log('valid');
+});
+
+
+data.date = new Date();
+Valida.process(data, schema, function(err, ctx) {
+  if (err) return console.log(err);
+  if (!ctx.isValid()) return console.log('invalid', ctx.errors());
+  console.log('valid');
+});
+
+
+data.date = 'Thu Sep 24 2015 11:31:30 GMT-0300 (BRT)';
+Valida.process(data, schema, function(err, ctx) {
+  if (err) return console.log(err);
+  if (!ctx.isValid()) return console.log('invalid', ctx.errors());
+  console.log('valid');
+});
+
+
+data.date = '2015-02-13';
+Valida.process(data, schema, function(err, ctx) {
+  if (err) return console.log(err);
+  if (!ctx.isValid()) return console.log('invalid', ctx.errors());
+  console.log('valid');
+});

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -124,6 +124,18 @@ validator.plainObject = function(ctx, options, value) {
 };
 
 
+validator.date = function(ctx, options, value) {
+  if (typeof value === 'undefined' || value === null) return;
+
+  var date = Date.parse(value);
+  if (isNaN(date)) {
+    var err = {validator: 'date'};
+    addMessage(err, options);
+
+    return err;
+  }
+}
+
 function addMessage (err, opt) {
   if (opt.msg) err.msg = opt.msg;
 }


### PR DESCRIPTION
Currently code have support to sanitize data to date, but this PR adds support to force data to come as date, it has some usages like the scenario:

Data can come as "empty" string, but when filled it must be a date, using sanitizer it will be always one date even when we pass one empty string.