### PR TITLE
Fix error message in len validator

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -64,7 +64,15 @@ validator.len = function(ctx, options, value) {
   if (options.min !== undefined && options.min > value.length) valid = false;
   if (options.max !== undefined && options.max < value.length) valid = false;
 
-  var err = { validator: 'len', min: options.min, max: options.max };
+  var err = { validator: 'len' };
+
+  if (options.min) {
+    err.min = options.min;
+  }
+  if (options.max) {
+    err.max = options.max;
+  }
+
   addMessage(err, options);
 
   if (!valid) return err;


### PR DESCRIPTION
In len validator it allows use min/max or both, but in error message it was not considering that is possible to send only one: min or max