### PR TITLE
Fixing valida for IE

### DIFF
--- a/lib/valida-invalid-error.js
+++ b/lib/valida-invalid-error.js
@@ -2,12 +2,36 @@ var util = require('util');
 
 
 var ValidaInvalidError = module.exports = function ValidaInvalidError (validationErrors) {
+  var message = 'validaInvalidError';
+
   Error.call(this);
 
   this.name = this.constructor.name;
-  Error.captureStackTrace(this, this.constructor);
-
   this.validationErrors = validationErrors;
+
+  Object.defineProperty(
+    this,
+    'message',
+    {
+      enumerable: false,
+      value: message,
+      writable: true,
+    }
+  );
+
+  if (Error.hasOwnProperty('captureStackTrace')) {
+    Error.captureStackTrace(this, this.constructor);
+    return;
+  }
+
+  Object.defineProperty(
+    this,
+    'stack',
+    {
+      enumerable: false,
+      value: (new Error(message)).stack,
+    }
+  );
 };
 
 


### PR DESCRIPTION
Valida was not working in internet explorer, mainly to relay on captureStackTrace that is not part of IE, this commit attempt to fix the issue, at least still working under chrome and i have tested in IE 9