### PR TITLE
add object keys sanitization

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -55,6 +55,14 @@ Context.prototype.groupsValid = function(groups) {
 };
 
 
+Context.prototype.sanitize = function() {
+  Object.keys(this.obj).forEach(function(key) {
+    if (!this.schema[key]) {
+      delete this.obj[key]
+    }
+  }, this);
+}
+
 Context.prototype.run = function() {
   Object.keys(this.schema).forEach(function (key) {
     var rules = this.schema[key];

--- a/lib/valida.js
+++ b/lib/valida.js
@@ -52,6 +52,7 @@ Valida.prototype.process = function(obj, schema, cb, groups) {
   }
 
   var ctx = new Valida.Context(this, obj, schema, cb, groups);
+  ctx.sanitize();
   ctx.run();
 
   return deferred.promise;

--- a/spec/valida.spec.js
+++ b/spec/valida.spec.js
@@ -1,0 +1,60 @@
+var Valida = require('../');
+var expect = require('chai').expect;
+
+describe('schema sanitization', function() {
+
+  context('with root key outside schema', function() {
+
+    let schema = {
+      name: [
+        { validator: Valida.Validator.required }
+      ]
+    }
+
+    it('should remove foreign key', function (done) {
+      var data = {
+        name: 'Jack',
+        surname: 'Sparrow'
+      };
+
+      Valida.process(data, schema, function(err, ctx) {
+        if (err) return done(err);
+        expect(Object.keys(data)).to.not.include('surname');
+        done();
+      });
+    });
+  });
+
+  context('with inner key outside schema', function() {
+
+    let schema = {
+      name: [
+        { validator: Valida.Validator.required }
+      ],
+      complex: [
+        { validator: Valida.Validator.required },
+        { validator: Valida.Validator.schema, schema: {
+          name: [
+            { validator: Valida.Validator.required }
+          ]
+        } }
+      ]
+    }
+
+    it('should remove foreign key', function (done) {
+      var data = {
+        name: 'Jack',
+        complex: {
+          name: 'Jack',
+          surname: 'Sparrow'
+        }
+      };
+
+      Valida.process(data, schema, function(err, ctx) {
+        if (err) return done(err);
+        expect(Object.keys(data.complex)).to.not.include('surname');
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Hi,
we add the ability to sanitize the object keys. For example if the schema don't contains a key, but the data contains it, before running the context we delete this key from the data. This can be helpful if the data come from a web api and the client send additional data to the server.

Bye