### PR TITLE
Add min/max to error message for range if defined

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -66,10 +66,10 @@ validator.len = function(ctx, options, value) {
 
   var err = { validator: 'len' };
 
-  if (options.min) {
+  if (options.min !== undefined) {
     err.min = options.min;
   }
-  if (options.max) {
+  if (options.max !== undefined) {
     err.max = options.max;
   }
 


### PR DESCRIPTION
Previous behavior was that if min or max were set to 0, they would, like if they were undefined, not be included in the error message for the range validator. This fixes it so that if they are defined, they will be added to the returned error.